### PR TITLE
Fix(i18n-seeker): support for multiple sub-keys

### DIFF
--- a/samples/case_05/i18n/fr/EASY.yml
+++ b/samples/case_05/i18n/fr/EASY.yml
@@ -1,0 +1,11 @@
+STOP: Stop
+START: Start
+PAUSE: Pause
+NOT_USED: Another One
+CAT:
+  SUBCAT_1:
+    KEY: Bonjour
+  SUBCAT_2:
+    ANOTHER: Key
+ONE_LEVEL:
+  OK: Ok

--- a/samples/case_05/src/sample.html
+++ b/samples/case_05/src/sample.html
@@ -1,0 +1,23 @@
+<template>
+
+  <div class="something else" title.one-time="'EASY:PAUSE' & t">?</div>
+        <div class="something else" title.bind="'EASY:START' & t">?</div>
+        <div class="something else" title.one-time="'EASY:START' & t">?</div>
+          <div class="something else" title.bind="'EASY:STOP' & t">?</div>
+
+          <div class="something else">${"EASY:KEY" & t} : </div>
+          <div class="something else">${'EASY:KEY2' | t} : </div>
+
+          <div>${"EASY:CAT.SUBCAT_1.KEY" & t} : </div>
+          <div>${'EASY:CAT.SUBCAT_2.ANOTHER' | t} : </div>
+          <div title.bind="'EASY:ONE_LEVEL.OK' & t">?</div>
+
+          <!-- ignore this -->
+          <div class="something else">${'EASY:KEY3'} : </div>
+
+    
+          <div class="something else" t="EASY:KEY"></div>
+          <div class="something else" t="EASY:KEY2"></div>
+          <!-- ignore this -->
+          <div class="something else" tt="EASY:KEY3"></div>
+</template>

--- a/samples/case_05/src/sample.ts
+++ b/samples/case_05/src/sample.ts
@@ -1,0 +1,29 @@
+export class Sample3 {
+  public i18n : any;
+
+  /**
+   */
+  public something() {
+    return this.i18n.tr('EASY:START');
+  }
+
+  /**
+   */
+  public summoner() {
+    return this.i18n.tr("EASY:STOP");
+  }
+
+  /**
+   */
+  public invocation() {
+    return this.i18n.tr("EASY:MIDDLE");
+  }
+
+  /**
+   */
+  public moon() {
+    // return true; this.i18n.tr("EASY:MOON");
+    return true; // this.i18n.tr("EASY:MOON");
+  }
+
+}

--- a/src/i18n/i18n-audit.spec.ts
+++ b/src/i18n/i18n-audit.spec.ts
@@ -237,6 +237,83 @@ describe('i18n-audit', () => {
       });
     });
 
+    describe('Subkeys', () => {
+      it('without srcPaths', async () => {
+        const audit = new I18NAudit(
+          new I18NAuditOptions({
+            srcPaths: undefined,
+            local: {
+              i18nPaths: [path.resolve('.\\samples\\case_05\\i18n')],
+            },
+            level: ELevel.EASY,
+          })
+        );
+
+        await audit.initializeAsync();
+        const details = await audit.validateAsync();
+        assert.strictEqual(details.isOk, true);
+        assert.strictEqual(details.languages.length, 1);
+        assert.strictEqual(details.unused.length, 7);
+        assert.strictEqual(Object.keys(details.missingKeys).length, 0);
+      });
+
+      it('easy', async () => {
+        const audit = new I18NAudit(
+          new I18NAuditOptions({
+            srcPaths: [path.resolve('.\\samples\\case_05\\src')],
+            local: {
+              i18nPaths: [path.resolve('.\\samples\\case_05\\i18n')],
+            },
+            level: ELevel.EASY,
+          })
+        );
+
+        await audit.initializeAsync();
+        const details = await audit.validateAsync();
+        assert.strictEqual(details.isOk, true);
+        assert.strictEqual(details.languages.length, 1);
+        assert.strictEqual(details.unused.length, 1);
+        assert.strictEqual(Object.keys(details.missingKeys).length, 3);
+      });
+
+      it('medium', async () => {
+        const audit = new I18NAudit({
+          srcPaths: [path.resolve('.\\samples\\case_05\\src')],
+          local: {
+            i18nPaths: [path.resolve('.\\samples\\case_05\\i18n')],
+          },
+          level: ELevel.MEDIUM,
+        });
+
+        await audit.initializeAsync();
+        const details = await audit.validateAsync();
+        assert.strictEqual(details.isOk, false);
+        assert.strictEqual(details.languages.length, 1);
+        assert.strictEqual(details.unused.length, 1);
+        assert.strictEqual(Object.keys(details.missingKeys).length, 3);
+      });
+
+      it('hard', async () => {
+        const audit = new I18NAudit({
+          srcPaths: [path.resolve('.\\samples\\case_05\\src')],
+          local: {
+            i18nPaths: [path.resolve('.\\samples\\case_05\\i18n')],
+          },
+          level: ELevel.HARD,
+          i18nConfig: {
+            attributes: [],
+          },
+        });
+
+        await audit.initializeAsync();
+        const details = await audit.validateAsync();
+        assert.strictEqual(details.isOk, false);
+        assert.strictEqual(details.languages.length, 1);
+        assert.strictEqual(details.unused.length, 1);
+        assert.strictEqual(Object.keys(details.missingKeys).length, 3);
+      });
+    });
+
     describe('remote', () => {
       const fakeI18nBackend = new FakeI18NBackend();
 

--- a/src/i18n/i18n-audit.ts
+++ b/src/i18n/i18n-audit.ts
@@ -169,7 +169,7 @@ export class I18NAudit {
       const defaultNS = this._options.i18nConfig.defaultNS;
 
       this._i18nSeeker.searchI18NKeys(content, ext, (rr, linePos, colPos) => {
-        this._createOrUpdateInCodeKeys(rr.ns || defaultNS, rr.subkey ? `${rr.key}.${rr.subkey}` : rr.key, filePath, linePos, colPos);
+        this._createOrUpdateInCodeKeys(rr.ns || defaultNS, rr.subkeys?.length ? `${rr.key}.${rr.subkeys.join('.')}` : rr.key, filePath, linePos, colPos);
       });
     }
   }

--- a/src/i18n/i18n-seeker.spec.ts
+++ b/src/i18n/i18n-seeker.spec.ts
@@ -491,7 +491,7 @@ function getI18NKeys(seeker: I18NSeeker, code: string, ext: string) {
   const keys: string[] = [];
 
   seeker.searchI18NKeys(code, ext, (res /*, linePos, colPos*/) => {
-    keys.push(`${res.ns ? res.ns + ':' : ''}${res.key || '_'}${res.subkey ? '.' + res.subkey : ''}`);
+    keys.push(`${res.ns ? res.ns + ':' : ''}${res.key || '_'}${res.subkeys?.length ? '.' + res.subkeys.join('.') : ''}`);
   });
   return keys.sort();
 }

--- a/src/i18n/i18n-seeker.ts
+++ b/src/i18n/i18n-seeker.ts
@@ -3,7 +3,7 @@ import { II18NConfig } from './i-i18n-config';
 export interface IRegexTagResult {
   ns?: string;
   key: string;
-  subkey?: string;
+  subkeys?: string[];
 }
 
 /**
@@ -44,46 +44,37 @@ export class I18NSeeker {
 
     this._i18nRegexTag = [
       {
-        /** [xxx]ns:key.nested or ns:key.nested */
-        regex: new RegExp(`(\\[[\\w\\-]{0,}\\])?([\\w\\-]{1,})${ns}([\\w\\-]{1,})${key}([\\w\\-]{1,})`, 'i'),
+        /** [xxx]ns:key.nested or ns:key.nested (get all the subkeys) */
+        regex: new RegExp(`(\\[[\\w\\-]{0,}\\])?([\\w\\-]+)${ns}([\\w\\-]+(?:${key}[\\w\\-]+)*)`, 'i'),
         parse: result => {
+          const keys = result.length > 3 ? result[3].split(key) : [];
           return {
             ns: result[2],
-            key: result[3],
-            subkey: result[4],
+            key: keys[0],
+            subkeys: keys.slice(1),
           };
         },
       },
       {
-        /** [xxx]ns:key or ns:key */
-        regex: new RegExp(`(\\[[\\w\\-]{0,}\\])?([\\w\\-]{1,})${ns}([\\w\\-]{1,})`, 'i'),
+        /** [xxx]key.nested or key.nested (get all the subkeys) */
+        regex: new RegExp(`(\\[[\\w\\-]{0,}\\])?([\\w\\-]+)${key}([\\w\\-]+(?:${key}[\\w\\-]+)*)`, 'i'),
         parse: result => {
+          const keys = result.length > 3 ? result[3].split(key) : [];
           return {
-            ns: result[2],
-            key: result[3],
-            subkey: null,
+            ns: null,
+            key: result[2],
+            subkeys: keys,
           };
         },
       },
       {
-        /** [xxx]key.nested or key.nested */
-        regex: new RegExp(`(\\[[\\w\\-]{0,}\\])?([\\w\\-]{1,})${key}([\\w\\-]{1,})`, 'i'),
+        /** [xxx]key key */
+        regex: new RegExp(`(\\[[\\w\\-]{0,}\\])?([\\w\\-]+)`, 'i'),
         parse: result => {
           return {
             ns: null,
             key: result[2],
-            subkey: result[3],
-          };
-        },
-      },
-      {
-        /** [xxx]key or key */
-        regex: new RegExp(`(\\[[\\w\\-]{0,}\\])?([\\w\\-]{1,})`, 'i'),
-        parse: result => {
-          return {
-            ns: null,
-            key: result[2],
-            subkey: null,
+            subkeys: [],
           };
         },
       },


### PR DESCRIPTION
Support for multiple sub-keys:

```yaml
KEY:
  SUBKEY: 'Subkey!'

  SUBKEY2:
     SUBKEY: 'Oh'

  SUBKEY3:
     SUBKEY:
       SUBKEY: 'Yeah'
  
```
- `NS:KEY.SUBKEY`
- `NS:KEY.SUBKEY2.SUBKEY`
- `NS:KEY.SUBKEY3.SUBKEY.SUBKEY` (etc!)

- `KEY.SUBKEY`
- `KEY.SUBKEY2.SUBKEY`
- `KEY.SUBKEY3.SUBKEY.SUBKEY` (etc!)